### PR TITLE
PasswordPolicyControl with value=null #956

### DIFF
--- a/lib/controls/password-policy-control.js
+++ b/lib/controls/password-policy-control.js
@@ -44,6 +44,10 @@ class PasswordPolicyControl extends Control {
       return
     }
 
+    if (options.value === null) {
+      return
+    }
+
     if (Buffer.isBuffer(options.value)) {
       this.#parse(options.value)
     } else if (isObject(options.value)) {

--- a/lib/controls/password-policy-control.test.js
+++ b/lib/controls/password-policy-control.test.js
@@ -50,6 +50,12 @@ tap.test('contructor', t => {
     t.throws(() => new PPC({ value: { timeBeforeExpiration: 1, graceAuthNsRemaining: 2 } }))
   })
 
+  // null value should not fail #956
+  t.test('no value shall not fail', async t => {
+    const control = new PPC({ value: null })
+    t.same(control.value, {})
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
I also encountered issue https://github.com/ldapjs/node-ldapjs/issues/956. Based on the provided [MRE](https://github.com/ldapjs/node-ldapjs/issues/956#issuecomment-1825965709), it appears that the value option is sometimes initialized with null instead of being just missing. The easiest way to eliminate the error would be to treat a null value the same as a missing value attribute.
